### PR TITLE
Fix broken "New Game" button

### DIFF
--- a/game.libretro.2048/resources/buttonmap.xml
+++ b/game.libretro.2048/resources/buttonmap.xml
@@ -9,7 +9,9 @@
     <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
     <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
     <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
+    <!-- Pause -->
     <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
-    <feature name="select" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+    <!-- New game -->
+    <feature name="back" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
   </controller>
 </buttonmap>


### PR DESCRIPTION
This fixes the "back" button on the 360 controller not starting a new game from the pause screen.

Button names are defined by the Controller Topology Project: https://github.com/kodi-game/controller-topology-project/blob/master/addons/game.controller.default/resources/layout.xml

## How Has This Been Tested?
Tested with 2048 on Windows 10.

## Screenshots (if appropriate):
![2048 pause screen](https://user-images.githubusercontent.com/531482/41070769-6b303fc8-69a9-11e8-88a0-d503acfb331a.png)
